### PR TITLE
feat(theme): add toggle-driven view transition

### DIFF
--- a/components/molecules/Navigation.tsx
+++ b/components/molecules/Navigation.tsx
@@ -106,6 +106,33 @@ const Navigation = React.memo(() => {
     "border-b border-divider",
     hidden && "-translate-y-full",
   );
+
+  const toggleThemeWithTransition = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      const nextTheme = isDarkTheme ? "light" : "dark";
+      const buttonRect = event.currentTarget.getBoundingClientRect();
+
+      document.documentElement.style.setProperty(
+        "--theme-transition-x",
+        `${buttonRect.left + buttonRect.width / 2}px`,
+      );
+      document.documentElement.style.setProperty(
+        "--theme-transition-y",
+        `${buttonRect.top + buttonRect.height / 2}px`,
+      );
+
+      if (!document.startViewTransition) {
+        setTheme(nextTheme);
+        return;
+      }
+
+      document.startViewTransition(() => {
+        setTheme(nextTheme);
+      });
+    },
+    [isDarkTheme, setTheme],
+  );
+
   return (
     <>
       <header className={NavigationStyles}>
@@ -159,16 +186,7 @@ const Navigation = React.memo(() => {
                       variant="ghost"
                       size="small"
                       className="ml-4 md:ml-10"
-                      onClick={() => {
-                        const theme = isDarkTheme ? "light" : "dark";
-                        if (!document.startViewTransition) {
-                          setTheme(theme);
-                          return;
-                        }
-                        document.startViewTransition(() => {
-                          setTheme(theme);
-                        });
-                      }}
+                      onClick={toggleThemeWithTransition}
                     >
                       {mounted ? (
                         isDarkTheme ? (

--- a/components/molecules/Navigation.tsx
+++ b/components/molecules/Navigation.tsx
@@ -125,54 +125,63 @@ const Navigation = React.memo(() => {
             </button>
             {!menuOpened && (
               <>
-              <div className="relative hidden items-center md:flex">
-                <ul className="flex items-center gap-8">
-                  {menuItems.map((item, i) => (
-                    <li key={i}>
-                      <NavigationLink
-                        href={item.href}
-                        isActive={currentActive == item.href}
-                        ref={(el) => {
-                          if (el) {
-                            menuRefs.current = {
-                              ...menuRefs.current,
-                              [item.href]: el,
-                            };
-                          }
-                        }}
-                      >
-                        {item.name}
-                      </NavigationLink>
-                    </li>
-                  ))}
-                </ul>
-                {currentActive && menuRefs.current[currentActive] && (
-                  <span
-                    className="bg-secondary absolute -bottom-3.75 h-1 w-0 origin-center rounded-t-full opacity-0 transition-all ease-in-out"
-                    style={indicatorStyle}
-                  ></span>
-                )}
-                <Tooltip
-                  content={`Switch to ${isDarkTheme ? "light" : "dark"} mode`}
-                >
-                  <IconButton
-                    variant="ghost"
-                    size="small"
-                    className="ml-4 md:ml-10"
-                    onClick={() => setTheme(isDarkTheme ? "light" : "dark")}
+                <div className="relative hidden items-center md:flex">
+                  <ul className="flex items-center gap-8">
+                    {menuItems.map((item, i) => (
+                      <li key={i}>
+                        <NavigationLink
+                          href={item.href}
+                          isActive={currentActive == item.href}
+                          ref={(el) => {
+                            if (el) {
+                              menuRefs.current = {
+                                ...menuRefs.current,
+                                [item.href]: el,
+                              };
+                            }
+                          }}
+                        >
+                          {item.name}
+                        </NavigationLink>
+                      </li>
+                    ))}
+                  </ul>
+                  {currentActive && menuRefs.current[currentActive] && (
+                    <span
+                      className="bg-secondary absolute -bottom-3.75 h-1 w-0 origin-center rounded-t-full opacity-0 transition-all ease-in-out"
+                      style={indicatorStyle}
+                    ></span>
+                  )}
+                  <Tooltip
+                    content={`Switch to ${isDarkTheme ? "light" : "dark"} mode`}
                   >
-                    {mounted ? (
-                      isDarkTheme ? (
-                        <FiSun />
+                    <IconButton
+                      variant="ghost"
+                      size="small"
+                      className="ml-4 md:ml-10"
+                      onClick={() => {
+                        const theme = isDarkTheme ? "light" : "dark";
+                        if (!document.startViewTransition) {
+                          setTheme(theme);
+                          return;
+                        }
+                        document.startViewTransition(() => {
+                          setTheme(theme);
+                        });
+                      }}
+                    >
+                      {mounted ? (
+                        isDarkTheme ? (
+                          <FiSun />
+                        ) : (
+                          <FiMoon />
+                        )
                       ) : (
                         <FiMoon />
-                      )
-                    ) : (
-                      <FiMoon />
-                    )}
-                  </IconButton>
-                </Tooltip>
-              </div>
+                      )}
+                    </IconButton>
+                  </Tooltip>
+                </div>
               </>
             )}
           </>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -18,6 +18,29 @@ const isProduction = process.env.NODE_ENV === "production";
 
 TimeAgo.addLocale(en);
 
+function SafariFlag() {
+  useEffect(() => {
+    const ua = window.navigator.userAgent;
+    const isSafari =
+      /Safari\//.test(ua) &&
+      !/Chrome\//.test(ua) &&
+      !/Chromium\//.test(ua) &&
+      !/Edg\//.test(ua) &&
+      !/OPR\//.test(ua) &&
+      !/CriOS\//.test(ua) &&
+      !/FxiOS\//.test(ua);
+
+    if (isSafari) {
+      document.documentElement.dataset.browser = "safari";
+      return;
+    }
+
+    delete document.documentElement.dataset.browser;
+  }, []);
+
+  return null;
+}
+
 function MyApp({ Component, pageProps }: AppProps) {
   const router = useRouter();
   useEffect(() => {
@@ -61,6 +84,7 @@ function MyApp({ Component, pageProps }: AppProps) {
         enableSystem
         disableTransitionOnChange
       >
+        <SafariFlag />
         {isProduction && (
           <>
             <Script

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -18,24 +18,48 @@ const isProduction = process.env.NODE_ENV === "production";
 
 TimeAgo.addLocale(en);
 
-function SafariFlag() {
-  useEffect(() => {
-    const ua = window.navigator.userAgent;
-    const isSafari =
-      /Safari\//.test(ua) &&
-      !/Chrome\//.test(ua) &&
-      !/Chromium\//.test(ua) &&
-      !/Edg\//.test(ua) &&
-      !/OPR\//.test(ua) &&
-      !/CriOS\//.test(ua) &&
-      !/FxiOS\//.test(ua);
+type NavigatorWithUAData = Navigator & {
+  userAgentData?: {
+    brands?: Array<{
+      brand: string;
+    }>;
+  };
+};
 
-    if (isSafari) {
-      document.documentElement.dataset.browser = "safari";
+function BrowserEngineFlag() {
+  useEffect(() => {
+    const html = document.documentElement;
+    const uaData = (window.navigator as NavigatorWithUAData).userAgentData;
+    const brands = uaData?.brands?.map((brand) => brand.brand) ?? [];
+    const hasChromiumBrand = brands.some((brand) =>
+      /Chromium|Google Chrome|Microsoft Edge|Opera/i.test(brand),
+    );
+    const hasNonChromiumBrand = brands.some((brand) =>
+      /Firefox|Safari/i.test(brand),
+    );
+
+    if (hasChromiumBrand && !hasNonChromiumBrand) {
+      html.dataset.browserEngine = "chromium";
       return;
     }
 
-    delete document.documentElement.dataset.browser;
+    const ua = window.navigator.userAgent;
+    const fallbackChromium =
+      (/Chrome\//.test(ua) ||
+        /Chromium\//.test(ua) ||
+        /Edg\//.test(ua) ||
+        /OPR\//.test(ua) ||
+        /CriOS\//.test(ua)) &&
+      !/Firefox\//.test(ua) &&
+      !/FxiOS\//.test(ua) &&
+      !/Safari\//.test(ua);
+
+    if (fallbackChromium) {
+      html.dataset.browserEngine = "chromium";
+      return;
+    }
+
+    delete html.dataset.browserEngine;
   }, []);
 
   return null;
@@ -84,7 +108,7 @@ function MyApp({ Component, pageProps }: AppProps) {
         enableSystem
         disableTransitionOnChange
       >
-        <SafariFlag />
+        <BrowserEngineFlag />
         {isProduction && (
           <>
             <Script

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -270,7 +270,19 @@
 
   ::view-transition-new(root) {
     --theme-transition-mask-size: 0px;
-    mask: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40"><defs><filter id="blur"><feGaussianBlur stdDeviation="2"/></filter></defs><circle cx="20" cy="20" r="18" fill="white" filter="url(%23blur)"/></svg>')
+    -webkit-mask:
+      url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40"><circle cx="20" cy="20" r="20" fill="white"/></svg>')
+      calc(
+        var(--theme-transition-x, 50%) - var(--theme-transition-mask-size) / 2
+      )
+      calc(
+        var(--theme-transition-y, 50%) - var(--theme-transition-mask-size) / 2
+      ) /
+      var(--theme-transition-mask-size) var(--theme-transition-mask-size)
+      no-repeat;
+    -webkit-mask-origin: content-box;
+    mask:
+      url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40"><circle cx="20" cy="20" r="20" fill="white"/></svg>')
       calc(
         var(--theme-transition-x, 50%) - var(--theme-transition-mask-size) / 2
       )
@@ -302,20 +314,9 @@
     }
   }
 
-  html[data-browser="safari"]::view-transition-new(root) {
-    -webkit-mask:
-      url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40"><circle cx="20" cy="20" r="20" fill="white"/></svg>')
-      calc(
-        var(--theme-transition-x, 50%) - var(--theme-transition-mask-size) / 2
-      )
-      calc(
-        var(--theme-transition-y, 50%) - var(--theme-transition-mask-size) / 2
-      ) /
-      var(--theme-transition-mask-size) var(--theme-transition-mask-size)
-      no-repeat;
-    -webkit-mask-origin: content-box;
+  html[data-browser-engine="chromium"]::view-transition-new(root) {
     mask:
-      url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40"><circle cx="20" cy="20" r="20" fill="white"/></svg>')
+      url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40"><defs><filter id="blur"><feGaussianBlur stdDeviation="2"/></filter></defs><circle cx="20" cy="20" r="18" fill="white" filter="url(%23blur)"/></svg>')
       calc(
         var(--theme-transition-x, 50%) - var(--theme-transition-mask-size) / 2
       )

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -271,8 +271,12 @@
   ::view-transition-new(root) {
     --theme-transition-mask-size: 0px;
     mask: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40"><defs><filter id="blur"><feGaussianBlur stdDeviation="2"/></filter></defs><circle cx="20" cy="20" r="18" fill="white" filter="url(%23blur)"/></svg>')
-      calc(var(--theme-transition-x, 50%) - var(--theme-transition-mask-size) / 2)
-      calc(var(--theme-transition-y, 50%) - var(--theme-transition-mask-size) / 2) /
+      calc(
+        var(--theme-transition-x, 50%) - var(--theme-transition-mask-size) / 2
+      )
+      calc(
+        var(--theme-transition-y, 50%) - var(--theme-transition-mask-size) / 2
+      ) /
       var(--theme-transition-mask-size) var(--theme-transition-mask-size)
       no-repeat;
     mask-origin: content-box;
@@ -296,6 +300,31 @@
     to {
       --theme-transition-mask-size: 350vmax;
     }
+  }
+
+  html[data-browser="safari"]::view-transition-new(root) {
+    -webkit-mask:
+      url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40"><circle cx="20" cy="20" r="20" fill="white"/></svg>')
+      calc(
+        var(--theme-transition-x, 50%) - var(--theme-transition-mask-size) / 2
+      )
+      calc(
+        var(--theme-transition-y, 50%) - var(--theme-transition-mask-size) / 2
+      ) /
+      var(--theme-transition-mask-size) var(--theme-transition-mask-size)
+      no-repeat;
+    -webkit-mask-origin: content-box;
+    mask:
+      url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40"><circle cx="20" cy="20" r="20" fill="white"/></svg>')
+      calc(
+        var(--theme-transition-x, 50%) - var(--theme-transition-mask-size) / 2
+      )
+      calc(
+        var(--theme-transition-y, 50%) - var(--theme-transition-mask-size) / 2
+      ) /
+      var(--theme-transition-mask-size) var(--theme-transition-mask-size)
+      no-repeat;
+    mask-origin: content-box;
   }
 }
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -250,6 +250,37 @@
   }
 }
 
+@layer base {
+  ::view-transition-group(root) {
+    animation-timing-function: var(--expo-out);
+  }
+
+  ::view-transition-old(root),
+  .dark::view-transition-old(root) {
+    animation: none;
+    animation-fill-mode: both;
+    z-index: -1;
+  }
+
+  ::view-transition-new(root) {
+    mask: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40"><defs><filter id="blur"><feGaussianBlur stdDeviation="2"/></filter></defs><circle cx="20" cy="20" r="18" fill="white" filter="url(%23blur)"/></svg>')
+      center / 0 no-repeat;
+    animation: scale 1s;
+    animation-fill-mode: both;
+  }
+
+  .dark::view-transition-new(root) {
+    animation: scale 1s;
+    animation-fill-mode: both;
+  }
+
+  @keyframes scale {
+    to {
+      mask-size: 200vmax;
+    }
+  }
+}
+
 /* Binary glitch animation for footer */
 @keyframes binary-glitch {
   0%,

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -251,6 +251,12 @@
 }
 
 @layer base {
+  @property --theme-transition-mask-size {
+    syntax: "<length>";
+    inherits: false;
+    initial-value: 0px;
+  }
+
   ::view-transition-group(root) {
     animation-timing-function: var(--expo-out);
   }
@@ -263,8 +269,13 @@
   }
 
   ::view-transition-new(root) {
+    --theme-transition-mask-size: 0px;
     mask: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40"><defs><filter id="blur"><feGaussianBlur stdDeviation="2"/></filter></defs><circle cx="20" cy="20" r="18" fill="white" filter="url(%23blur)"/></svg>')
-      center / 0 no-repeat;
+      calc(var(--theme-transition-x, 50%) - var(--theme-transition-mask-size) / 2)
+      calc(var(--theme-transition-y, 50%) - var(--theme-transition-mask-size) / 2) /
+      var(--theme-transition-mask-size) var(--theme-transition-mask-size)
+      no-repeat;
+    mask-origin: content-box;
     animation: scale 1s;
     animation-fill-mode: both;
   }
@@ -274,9 +285,16 @@
     animation-fill-mode: both;
   }
 
+  ::view-transition-old(root),
+  .dark::view-transition-old(root) {
+    animation: none;
+    animation-fill-mode: both;
+    z-index: -1;
+  }
+
   @keyframes scale {
     to {
-      mask-size: 200vmax;
+      --theme-transition-mask-size: 350vmax;
     }
   }
 }

--- a/styles/variables.css
+++ b/styles/variables.css
@@ -112,6 +112,25 @@
     --content-group-spacing: 2rem;
     --content-section-spacing: 2.5rem;
 
+    --expo-out: linear(
+      0 0%,
+      0.1684 2.66%,
+      0.3165 5.49%,
+      0.446 8.52%,
+      0.5581 11.78%,
+      0.6535 15.29%,
+      0.7341 19.11%,
+      0.8011 23.3%,
+      0.8557 27.93%,
+      0.8962 32.68%,
+      0.9283 38.01%,
+      0.9529 44.08%,
+      0.9711 51.14%,
+      0.9833 59.06%,
+      0.9915 68.74%,
+      1 100%
+    );
+
     @media (width >= theme(--breakpoint-md)) {
       --section-horizontal-padding: 1.5rem;
       --section-vertical-padding: 3rem;


### PR DESCRIPTION
## Summary
- add a view transition animation when toggling between light and dark themes
- compute the transition origin from the theme toggle button position
- center the reveal mask so the blur expansion stays aligned with the toggle icon

## Testing
- npx tsc --noEmit