### PR TITLE
fix(theme): tune chromium blur mask bounds

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -316,7 +316,7 @@
 
   html[data-browser-engine="chromium"]::view-transition-new(root) {
     mask:
-      url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40"><defs><filter id="blur"><feGaussianBlur stdDeviation="2"/></filter></defs><circle cx="20" cy="20" r="18" fill="white" filter="url(%23blur)"/></svg>')
+      url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 52 52"><defs><filter id="blur" x="-50%25" y="-50%25" width="200%25" height="200%25"><feGaussianBlur stdDeviation="2"/></filter></defs><circle cx="26" cy="26" r="20" fill="white" filter="url(%23blur)"/></svg>')
       calc(
         var(--theme-transition-x, 50%) - var(--theme-transition-mask-size) / 2
       )


### PR DESCRIPTION
## Summary
- keep plain theme-transition masks as the default path for non-Chromium browsers
- refine Chromium-only blur handling with a tighter 52x52 SVG mask canvas
- preserve the expanded filter region so the blur edge has room without feeling overly slow

## Testing
- npx tsc --noEmit